### PR TITLE
Added Current Game API

### DIFF
--- a/lib/api/currentGame.js
+++ b/lib/api/currentGame.js
@@ -1,0 +1,52 @@
+module.exports = function (region) {
+  'use strict';
+
+  var config = require('../config');
+  var util = require('../util');
+
+  var getPlatformId = function (region) {
+    switch (region) {
+      case 'br':
+        return 'BR1';
+      case 'na':
+        return 'NA1';
+      case 'lan':
+        return 'LA1';
+      case 'las':
+        return 'LA2';
+      case 'oce':
+        return 'OC1';
+      case 'eune':
+        return 'EUN1';
+      case 'euw':
+        return 'EUW1';
+      case 'tr':
+        return 'TR1';
+      case 'ru':
+        return 'RU';
+      case 'kr':
+        return 'KR';
+      default:
+        throw 'Your region is incorrect';
+    }
+  }
+
+  return {
+    getBySummonerId: function (summonerId, options, callback) {
+      if (arguments.length === 2 && typeof options === 'function') {
+        callback = arguments[1];
+        options = null;
+      }
+
+      options = options || {};
+      options.region = options.region || region || config.defaultRegion;
+      options.uri = config.uri.CURRENT_GAME;
+      options.id = summonerId;
+      options.platformId = getPlatformId(options.region);
+      options.host = 'https://' + options.region + '.api.pvp.net';
+
+      util.exec(options, callback);
+    }
+  };
+
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,8 @@ module.exports = {
     // Champion
     CHAMPION_LIST: '/{string:region}/v1.2/champion',
     CHAMPION_ID: '/{string:region}/v1.2/champion/{int:id}',
+    // Current Game
+    CURRENT_GAME: '/observer-mode/rest/consumer/getSpectatorGameInfo/{string:platformId}/{int:id}',
     // Game
     RECENT_GAMES: '/{string:region}/v1.3/game/by-summoner/{int:id}/recent',
     // League

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -18,6 +18,7 @@ module.exports = function (apiKey, region, options) {
 
   var api = {};
   api.Champion = require('./api/champion')(region);
+  api.CurrentGame = require('./api/currentGame')(region);
   api.Game = require('./api/game')(region);
   api.League = require('./api/league')(region);
   api.Static = require('./api/static')(region);

--- a/lib/util.js
+++ b/lib/util.js
@@ -186,8 +186,6 @@ module.exports = (function () {
 
   };
 
-
-
   util.schedule = function (fn, callback) {
     _limiterPer10s.schedule(function () {
         _limiterPer10min.schedule(fn);
@@ -208,6 +206,10 @@ module.exports = (function () {
       });
 
       response.on('end', function () {
+        if (response.statusCode !== 200) {
+          callback(response.statusCode + ' ' + response.statusMessage, null);
+        }
+
         try {
           data = JSON.parse(data);
         } catch (error) {
@@ -215,15 +217,12 @@ module.exports = (function () {
           return;
         }
 
-        if (data.status && data.status.message !== 200) {
-            callback(data.status.status_code + ' ' + data.status.message, null);
-        } else {
-          if (_useRedis || options.cacheRequest) {
-            redis.set(options.uri, JSON.stringify(data));
-            redis.expire(options.uri, _cacheTTL);
-          }
-          callback(null, data);
+        if (_useRedis || options.cacheRequest) {
+          redis.set(options.uri, JSON.stringify(data));
+          redis.expire(options.uri, _cacheTTL);
         }
+
+        callback(null, data);
       });
     });
   };


### PR DESCRIPTION
I added the Current Game API that riot recently released. The url of this nem API uses a `platformId` for each regions, and I couldn't find a better way than the `switch` depending on the region.

Also, the commit 4bce05290b7318e35d7d1ca3a09c2d26e9503937 updates the `util._get` method to handle with 404 error, which sometimes didn't come as a json but as an HTML page.
