### PR TITLE
Fix URLEncoding summoner name

### DIFF
--- a/lib/api/summoner.js
+++ b/lib/api/summoner.js
@@ -28,7 +28,7 @@ module.exports = function (region) {
       options = options || {};
       options.region = options.region || region || config.defaultRegion;
       options.uri = config.uri.SUMMONER_BY_NAME;
-      options.names = summonerNames instanceof Array ? summonerNames.join() : summonerNames;
+      options.names = encodeURIComponent(summonerNames instanceof Array ? summonerNames.join() : summonerNames);
 
       util.exec(options, callback);
     },


### PR DESCRIPTION
Using summoner API with a summoner name with unicode characters resulted in error (400 Bad request). 
Summoner names should to be URIEncoded.
